### PR TITLE
Fix security hole in GateKeeperResponse.

### DIFF
--- a/core/java/android/service/gatekeeper/GateKeeperResponse.java
+++ b/core/java/android/service/gatekeeper/GateKeeperResponse.java
@@ -85,6 +85,8 @@ public final class GateKeeperResponse implements Parcelable {
             if (mPayload != null) {
                 dest.writeInt(mPayload.length);
                 dest.writeByteArray(mPayload);
+            } else {
+                dest.writeInt(0);
             }
         }
     }


### PR DESCRIPTION
GateKeeperResponse has inconsistent writeToParcel() and
createFromParcel() methods, making it possible for a malicious app to
create a Bundle that changes contents after reserialization. Such
Bundles can be used to execute Intents with system privileges.

This CL changes writeToParcel() to make serialization and
deserialization consistent, thus fixing the issue.

Bug: 62998805
Test: use the debug app (see bug)
Change-Id: Ie1c64172c454c3a4b7a0919eb3454f0e38efcd09
(cherry picked from commit e74cae8f7c3e6b12f2bf2b75427ee8f5b53eca3c)