### PR TITLE
DPC should not be allowed to grant development permission

### DIFF
--- a/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
+++ b/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
@@ -71,6 +71,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.PackageManagerInternal;
 import android.content.pm.ParceledListSlice;
+import android.content.pm.PermissionInfo;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ServiceInfo;
 import android.content.pm.UserInfo;
@@ -123,6 +124,7 @@ import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import android.util.ArrayMap;
 import android.util.ArraySet;
+import android.util.EventLog;
 import android.util.Log;
 import android.util.Pair;
 import android.util.Slog;
@@ -8621,6 +8623,10 @@ public class DevicePolicyManagerService extends IDevicePolicyManager.Stub {
                         < android.os.Build.VERSION_CODES.M) {
                     return false;
                 }
+                if (!isRuntimePermission(permission)) {
+                    EventLog.writeEvent(0x534e4554, "62623498", user.getIdentifier(), "");
+                    return false;
+                }
                 final PackageManager packageManager = mContext.getPackageManager();
                 switch (grantState) {
                     case DevicePolicyManager.PERMISSION_GRANT_STATE_GRANTED: {
@@ -8645,6 +8651,8 @@ public class DevicePolicyManagerService extends IDevicePolicyManager.Stub {
                 }
                 return true;
             } catch (SecurityException se) {
+                return false;
+            } catch (NameNotFoundException e) {
                 return false;
             } finally {
                 mInjector.binderRestoreCallingIdentity(ident);
@@ -8689,6 +8697,13 @@ public class DevicePolicyManagerService extends IDevicePolicyManager.Stub {
         } catch (RemoteException re) {
             throw new RuntimeException("Package manager has died", re);
         }
+    }
+
+    public boolean isRuntimePermission(String permissionName) throws NameNotFoundException {
+        final PackageManager packageManager = mContext.getPackageManager();
+        PermissionInfo permissionInfo = packageManager.getPermissionInfo(permissionName, 0);
+        return (permissionInfo.protectionLevel & PermissionInfo.PROTECTION_MASK_BASE)
+                == PermissionInfo.PROTECTION_DANGEROUS;
     }
 
     @Override


### PR DESCRIPTION
Test: cts-tradefed run cts-dev --module CtsDevicePolicyManagerTestCases --t  com.android.cts.devicepolicy.MixedDeviceOwnerTest#testPermissionGrant_developmentPermission
Test: cts-tradefed run cts-dev --module CtsDevicePolicyManagerTestCases --t  com.android.cts.devicepolicy.MixedProfileOwnerTest#testPermissionGrant_developmentPermission
Test: cts-tradefed run cts-dev --module CtsDevicePolicyManagerTestCases --t  com.android.cts.devicepolicy.MixedDeviceOwnerTest#testPermissionGrant
Test: cts-tradefed run cts-dev --module CtsDevicePolicyManagerTestCases --t  com.android.cts.devicepolicy.MixedProfileOwnerTest#testPermissionGrant
Test: Run "Permissions lockdown" test in CtsVerifier

Bug: 62623498

Merged-In: If83d8edd0eea99145421e967ae47fdc264a5cf7c

Change-Id: I129bfe850981cf0b3646b7c1cf19c8a3ec69f512
(cherry picked from commit d05d2bac845048f84eebad8060d28332b6eda259)